### PR TITLE
Upgrade swagger-ui to v3.23.11

### DIFF
--- a/tornado_swagger/swagger_ui/ui.jinja2
+++ b/tornado_swagger/swagger_ui/ui.jinja2
@@ -24,10 +24,10 @@
         background: #fafafa;
     }
 </style>
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui.css">
-<script src='https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui-bundle.js'
+<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui.css">
+<script src='https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui-bundle.js'
         type='text/javascript'></script>
-<script src='https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui-standalone-preset.js'
+<script src='https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.11/swagger-ui-standalone-preset.js'
         type='text/javascript'></script>
 <script type="text/javascript">
     window.SWAGGER_CONFIG_URL = "##SWAGGER_CONFIG##";


### PR DESCRIPTION
Release notes for [v3.23.11][v3.23.11].

This is not the latest release, but v3.24 is not yet available on [cdnjs.com][cdnjs]

[v3.23.11]: https://github.com/swagger-api/swagger-ui/releases/tag/v3.23.11
[cdnjs]: https://cdnjs.com/libraries/swagger-ui/3.23.11