### PR TITLE
Prepend the swagger routes instead of appending.

### DIFF
--- a/tornado_swagger/setup.py
+++ b/tornado_swagger/setup.py
@@ -71,4 +71,3 @@ def setup_swagger(routes: typing.List[tornado.web.URLSpec],
                 json.dumps(swagger_schema)
             )
         )
-

--- a/tornado_swagger/setup.py
+++ b/tornado_swagger/setup.py
@@ -59,7 +59,7 @@ def setup_swagger(routes: typing.List[tornado.web.URLSpec],
                     else swagger_url)
     _base_swagger_url = _swagger_url.rstrip('/')
 
-    routes += [
+    routes[:0] = [
         tornado.web.url(_swagger_url, SwaggerHomeHandler),
         tornado.web.url('{}/'.format(_base_swagger_url), SwaggerHomeHandler),
     ]
@@ -71,3 +71,4 @@ def setup_swagger(routes: typing.List[tornado.web.URLSpec],
                 json.dumps(swagger_schema)
             )
         )
+


### PR DESCRIPTION
First of all thank you for your great  package, it works very well!     


## Why the change?
When using a static file handler, the swagger routes will be appended to the routes list. Therefore, the static file handler doesn't work anymore.

Current way to fix the issue:

    routes = [  
            tornado.web.url(r'/api2', Handler2),  
            tornado.web.url(r'/api', Handler)
        ]  
    setup_swagger(routes=routes)  
    routes.append(tornado.web.url(r'/(.*)', tornado.web.StaticFileHandler, {'path': 'path'}))  
    swagger_app = tornado.web.Application(routes)
        
## Proposal: 
Prepend the swagger handler instead of appending.

Desired result:

    routes = [  
        tornado.web.url(r'/api2', Handler2),  
        tornado.web.url(r'/api', Handler),  
        tornado.web.url(r'/(.*)', tornado.web.StaticFileHandler, {'path': 'path'})  
    ]  
    setup_swagger(routes=routes)  
    swagger_app = tornado.web.Application(routes)


For the failing build:
[Gitlab Issue](https://gitlab.com/pycqa/flake8/-/issues/640)