### PR TITLE
swagger api auth

### DIFF
--- a/examples/auth_server.py
+++ b/examples/auth_server.py
@@ -32,7 +32,7 @@ class AuthHandler(tornado.web.RequestHandler):
               description: the auth key return
         """
         x_api_key = self.request.headers.get('X-API-Key')
-        self.finish(f"the x-api-key request get is {x_api_key}")
+        self.finish("the x-api-key request get is %s" % x_api_key)
 
 
 class Application(tornado.web.Application):

--- a/examples/auth_server.py
+++ b/examples/auth_server.py
@@ -1,0 +1,77 @@
+import tornado.ioloop
+import tornado.options
+import tornado.web
+
+from tornado_swagger.setup import setup_swagger
+
+
+class AuthHandler(tornado.web.RequestHandler):
+    def get(self):
+        """
+        ---
+        tags:
+        - Auth
+        summary: Get user auth key
+        description: Get user auth key
+        produces:
+        - application/json
+        """
+        self.finish("test user auth")
+
+    def post(self):
+        """
+        ---
+        tags:
+        - Auth
+        summary: Check user auth
+        description: check user auth
+        produces:
+        - application/json
+        responses:
+            200:
+              description: the auth key return
+        """
+        x_api_key = self.request.headers.get('X-API-Key')
+        self.finish(f"the x-api-key request get is {x_api_key}")
+
+
+class Application(tornado.web.Application):
+    _routes = [
+        tornado.web.url(r'/api/auth', AuthHandler),
+    ]
+
+    def __init__(self):
+        settings = {
+            'debug': True
+        }
+
+        setup_swagger(self._routes,
+                      swagger_url='/doc',
+                      api_base_url='/',
+                      description='',
+                      api_version='1.0.0',
+                      title='Journal API',
+                      contact='name@domain',
+                      security_definitions={
+                          'ApiKeyAuth': {
+                              'type': 'apiKey',
+                              'in': 'header',
+                              'name': 'X-API-Key'
+                          }
+                      },
+                      security=[
+                          {
+                              'ApiKeyAuth': []
+                          }
+                      ])
+        super(Application, self).__init__(self._routes, **settings)
+
+
+if __name__ == '__main__':
+    tornado.options.define('port', default='8080', help='Port to listen on')
+    tornado.options.parse_command_line()
+
+    app = Application()
+    app.listen(port=8080)
+
+    tornado.ioloop.IOLoop.current().start()

--- a/tests/helpers/test_builders.py
+++ b/tests/helpers/test_builders.py
@@ -91,7 +91,8 @@ def test_generate_doc_from_each_end_point():
         title='',
         contact='',
         security_definitions=None,
-        schemes=[]
+        schemes=[],
+        security=None
     )
     assert docs
 

--- a/tornado_swagger/_builders.py
+++ b/tornado_swagger/_builders.py
@@ -112,7 +112,8 @@ def generate_doc_from_endpoints(routes: typing.List[tornado.web.URLSpec],
                                 title,
                                 contact,
                                 schemes,
-                                security_definitions):
+                                security_definitions,
+                                security):
     from tornado_swagger.model import swagger_models
     # Clean description
     _start_desc = 0
@@ -137,7 +138,10 @@ def generate_doc_from_endpoints(routes: typing.List[tornado.web.URLSpec],
             'name': contact
         }
     if security_definitions:
-        swagger['securityDefinitions'] = nesteddict2yaml(security_definitions)
+        swagger['securityDefinitions'] = security_definitions
+
+    if security:
+        swagger['security'] = security
 
     swagger['schemes'] = schemes
     swagger['paths'] = collections.defaultdict(dict)

--- a/tornado_swagger/setup.py
+++ b/tornado_swagger/setup.py
@@ -18,7 +18,8 @@ def export_swagger(routes: typing.List[tornado.web.URLSpec],
                    title: str = 'Swagger API',
                    contact: str = '',
                    schemes: list = None,
-                   security_definitions: dict = None
+                   security_definitions: dict = None,
+                   security: list = None,
                    ):
     return generate_doc_from_endpoints(
         routes,
@@ -29,6 +30,7 @@ def export_swagger(routes: typing.List[tornado.web.URLSpec],
         contact=contact,
         schemes=schemes,
         security_definitions=security_definitions,
+        security=security
     )
 
 
@@ -42,6 +44,7 @@ def setup_swagger(routes: typing.List[tornado.web.URLSpec],
                   contact: str = '',
                   schemes: list = None,
                   security_definitions: dict = None,
+                  security: list = None,
                   display_models: bool = True
                   ):
     swagger_schema = generate_doc_from_endpoints(
@@ -53,6 +56,7 @@ def setup_swagger(routes: typing.List[tornado.web.URLSpec],
         contact=contact,
         schemes=schemes,
         security_definitions=security_definitions,
+        security=security
     )
 
     _swagger_url = ('/{}'.format(swagger_url)

--- a/tornado_swagger/setup.py
+++ b/tornado_swagger/setup.py
@@ -19,7 +19,7 @@ def export_swagger(routes: typing.List[tornado.web.URLSpec],
                    contact: str = '',
                    schemes: list = None,
                    security_definitions: dict = None,
-                   security: list = None,
+                   security: list = None
                    ):
     return generate_doc_from_endpoints(
         routes,


### PR DESCRIPTION
Add swagger auth,There is a problem with the original example `model_declaration.py`.
the swagger config we generate is in JSON format,but the `_builders.py` cast to yaml string.And the config missing config `security`