### PR TITLE
Add possibility to register parameters 

### DIFF
--- a/examples/model_and_param_declaration.py
+++ b/examples/model_and_param_declaration.py
@@ -3,6 +3,7 @@ import tornado.options
 import tornado.web
 
 from tornado_swagger.model import register_swagger_model
+from tornado_swagger.parameter import register_swagger_parameter
 from tornado_swagger.setup import setup_swagger
 
 
@@ -55,11 +56,7 @@ class PostsDetailsHandler(tornado.web.RequestHandler):
         produces:
         - application/json
         parameters:
-        -   name: posts_id
-            in: path
-            description: ID of post to return
-            required: true
-            type: string
+        -   $ref: '#/parameters/PostId'
         responses:
             200:
               description: list of posts
@@ -77,11 +74,7 @@ class PostsDetailsHandler(tornado.web.RequestHandler):
         produces:
         - application/json
         parameters:
-        -   name: posts_id
-            in: path
-            description: ID of post to edit
-            required: true
-            type: string
+        -   $ref: '#/parameters/PostId'
         -   in: body
             name: body
             description: post data
@@ -100,12 +93,20 @@ class PostsDetailsHandler(tornado.web.RequestHandler):
         produces:
         - application/json
         parameters:
-        -   name: posts_id
-            in: path
-            description: ID of post to delete
-            required: true
-            type: string
+        -   $ref: '#/parameters/PostId'
         """
+
+
+@register_swagger_parameter
+class PostId:
+    """
+    ---
+    name: posts_id
+    in: path
+    description: ID of post
+    required: true
+    type: string
+    """
 
 
 @register_swagger_model

--- a/tornado_swagger/_builders.py
+++ b/tornado_swagger/_builders.py
@@ -137,6 +137,7 @@ def generate_doc_from_endpoints(
 ):
     """Generate doc based on routes"""
     from tornado_swagger.model import export_swagger_models  # pylint: disable=C0415
+    from tornado_swagger.parameter import export_swagger_parameters
 
     swagger_spec = {
         "swagger": "2.0",
@@ -148,6 +149,7 @@ def generate_doc_from_endpoints(
         "basePath": api_base_url,
         "schemes": schemes,
         "definitions": export_swagger_models(),
+        "parameters": export_swagger_parameters(),
         "paths": _extract_paths(routes),
     }
     if contact:

--- a/tornado_swagger/parameter.py
+++ b/tornado_swagger/parameter.py
@@ -1,0 +1,26 @@
+from tornado_swagger._builders import build_swagger_docs
+
+
+class _SwaggerParameterStore:
+    """Singleton with parameter definitions"""
+
+    definitions = {}
+
+
+def _save_parameter_doc(model):
+    """Save model docstring to _SwaggerParameterStore"""
+    doc = model.__doc__
+
+    if doc is not None and "---" in doc:
+        _SwaggerParameterStore.definitions[model.__name__] = build_swagger_docs(doc)
+
+
+def export_swagger_parameters():
+    """Get swagger parameters definition"""
+    return _SwaggerParameterStore.definitions
+
+
+def register_swagger_parameter(model):
+    """Register parameter definition in swagger"""
+    _save_parameter_doc(model)
+    return model


### PR DESCRIPTION
This is to support registering parameters #51 .
I adjusted the model_declaration-example to cover parameter-declaration, too.

It's officially supported that way by OAS 2:
https://swagger.io/docs/specification/2-0/describing-parameters/